### PR TITLE
Added support to joins on AR

### DIFF
--- a/lib/data_table/active_record.rb
+++ b/lib/data_table/active_record.rb
@@ -1,10 +1,25 @@
 module DataTable
   module ActiveRecord
     module ClassMethods
+
       def _find_objects params, fields, search_fields
         self.where(_where_conditions params[:sSearch], search_fields).
+             includes(_discover_joins fields).
              order(_order_fields params, fields).
              paginate :page => _page(params), :per_page => _per_page(params)
+      end
+
+      def _discover_joins fields
+        joins = Set.new
+
+        fields.each { |it|
+          field = it.split('.')
+          if (field.size == 2) then
+            joins.add field[0].singularize.to_sym
+          end
+        }
+
+        joins.collect
       end
 
       def _where_conditions query, search_fields

--- a/spec/active_record_data_table_spec.rb
+++ b/spec/active_record_data_table_spec.rb
@@ -9,10 +9,11 @@ describe DataTable do
     it "should find the objects required based on the params" do
       params = {:sSearch => "answer", :iSortCol_0 => "0", :sSortDir_0 => "desc", :iDisplayLength => 10, :sEcho => 1}
 
+      mock(self)._discover_joins(%w(foo bar baz)) { [] }
       mock(self)._where_conditions("answer", %w(foo bar)) { "where clause" }
       mock(self)._order_fields(params, %w(foo bar baz)) { "order" }
 
-      mock(self).where("where clause") { mock!.order("order") { mock!.paginate({:page => :page, :per_page => :per_page}) { :answer } } }
+      mock(self).where("where clause") { mock!.includes([]) { mock!.order("order") { mock!.paginate({:page => :page, :per_page => :per_page}) { :answer } } } }
       mock(self)._page(params) { :page }
       mock(self)._per_page(params) { :per_page }
 
@@ -30,6 +31,14 @@ describe DataTable do
     it "should return an AR array with an entry for each search field" do
       send(:_where_conditions, "query", %w(foo bar)).should == ["UPPER(foo) LIKE ? OR UPPER(bar) LIKE ?", "%QUERY%", "%QUERY%"]
     end
+
+  end
+
+  context "#_discover_joins" do
+
+     it "should return the joins on the fields" do
+       _discover_joins(%w(foo.bar foz.ber baz)).should == [:foo, :foz]
+     end
 
   end
 


### PR DESCRIPTION
I don't know if this is the best solution, but simply pass:

``` ruby
render(:json => Provider.for_data_table(self, %w(name fein categories.name county state), %w(name fein)) do |provider|
            ["<%= link_to(provider, provider) %>", provider.fein, provider.category.name, provider.county, provider.state]
          end)
```

Tested using belongs_to but should work with has_one too.
