### PR TITLE
Fixing joins support for ActiveRecord

### DIFF
--- a/lib/data_table/active_record.rb
+++ b/lib/data_table/active_record.rb
@@ -11,15 +11,21 @@ module DataTable
 
       def _discover_joins fields
         joins = Set.new
+        object = self.new
 
         fields.each { |it|
           field = it.split('.')
+
           if (field.size == 2) then
-            joins.add field[0].singularize.to_sym
+            if object.respond_to?(field[0].to_sym)
+              joins.add field[0].to_sym
+            elsif object.respond_to?(field[0].singularize.to_sym)
+              joins.add field[0].singularize.to_sym
+            end
           end
         }
 
-        joins.collect
+        joins.to_a
       end
 
       def _where_conditions query, search_fields

--- a/spec/active_record_data_table_spec.rb
+++ b/spec/active_record_data_table_spec.rb
@@ -36,9 +36,18 @@ describe DataTable do
 
   context "#_discover_joins" do
 
-     it "should return the joins on the fields" do
-       _discover_joins(%w(foo.bar foz.ber baz)).should == [:foo, :foz]
-     end
+    it "should return the joins on the fields" do
+      mock(self).new {self}
+      stub(self).foo {true}
+      stub(self).foz {true}
+      stub(self).furs {true}
+
+      joins = _discover_joins(%w(foo.bar foz.ber furs.bib nones.zip baz))
+      joins.should include :foo
+      joins.should include :foz
+      joins.should include :furs
+      joins.should_not include :nones
+    end
 
   end
 


### PR DESCRIPTION
I was getting ActiveRecord::ConfigurationError when using the joins support.  It was caused by the use of Set.  The collect method was not returning an array.  Also it was changing all joins to the singular form which caused has_many associations to be improperly configured.
