### PR TITLE
add support for single column search

### DIFF
--- a/lib/data_table/active_record.rb
+++ b/lib/data_table/active_record.rb
@@ -101,9 +101,9 @@ module DataTable
 
       def _date_where_condition query, field
         begin
-          ["#{field} = ?", Date.parse(query)]
+          ["#{field}::date = ?", Date.parse(query)]
         rescue ArgumentError
-          []
+          ["NULL!= ?", nil]
         end
       end
 


### PR DESCRIPTION
i needed filtering of single columns for a project, so i created these lines. I'm sure it's not the most beautiful code but as i'm new to ruby/rails and git i hope you will forgive me. probably this code is more an inspiration than a final solution. I would really appreciate if someone will support me to write some better code ;)
- the order of "search_fields" needs to be the order of the columns that are filtered - maybe that's not the best solution, would a new param be a better solution?
