### PR TITLE
Allow for defining ambiguous column names

### DIFF
--- a/lib/data_table/active_record.rb
+++ b/lib/data_table/active_record.rb
@@ -17,6 +17,8 @@ module DataTable
           field = it.split('.')
 
           if (field.size == 2) then
+            next if object.class.name.downcase == field[0].singularize
+
             if object.respond_to?(field[0].to_sym)
               joins.add field[0].to_sym
             elsif object.respond_to?(field[0].singularize.to_sym)


### PR DESCRIPTION
This allows for `User.for_data_table(self, %w(users.name groups.name)`
